### PR TITLE
Fixed subdomains on production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,7 +104,4 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-
-  # Support subdomains
-  config.action_dispatch.tld_length = 2
 end


### PR DESCRIPTION
The tld_length config option is used for cases in which the domain of a Rails app has more than one dot, e.g. bbc.co.uk. This is not the case with stuyspec.com, which caused errors in production.