### PR TITLE
Stopped headers changing on every request.

### DIFF
--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -3,7 +3,7 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.


### PR DESCRIPTION
Currently, session handling code is mysteriously broken on both stuyspec.com and cms, as some queries, mutations, and validateToken requests just don't return headers. This temporarily "fixes" the problem by keeping headers static for the duration they're valid.