### PR TITLE
Keep session headers the same after mutations

### DIFF
--- a/app/graphql/resolvers/mutation_function.rb
+++ b/app/graphql/resolvers/mutation_function.rb
@@ -14,10 +14,11 @@ class Resolvers::MutationFunction < GraphQL::Function
     set_headers(ctx)
     set_user(ctx)
 
-    client_id = @headers['client']
-    new_auth_header = @user.create_new_auth_token(client_id)
-    response = ctx[:response]
-    response.headers.merge!(new_auth_header)
+    # Updates headers: functionality turned off
+    # client_id = @headers['client']
+    # new_auth_header = @user.create_new_auth_token(client_id)
+    # response = ctx[:response]
+    # response.headers.merge!(new_auth_header)
   end
 
   private


### PR DESCRIPTION
This completes the disabling of changing auth headers per request. Keeping state had proved extremly difficult in the old system.