### PR TITLE
Allow subsection articles to be included in latestArticles, add query for unpublished articles

### DIFF
--- a/app/graphql/resolvers/get_latest_articles.rb
+++ b/app/graphql/resolvers/get_latest_articles.rb
@@ -3,21 +3,31 @@ class Resolvers::GetLatestArticles < Resolvers::ArticleQueryFunction
   argument :section_id, types.ID
   argument :offset, types.Int
   argument :limit, types.Int
+  argument :include_subsections, types.Boolean
 
   # return type from the mutation
-  type types[Types::ArticleType]
+  type types[!Types::ArticleType]
 
   # the mutation method
   # _obj - is parent object, which in this case is nil
   # _args - are the arguments passed
   # _ctx - is the GraphQL context (which would be discussed later)
   def call(_obj, args, _ctx)
-    articles = Article.order(created_at: :desc)
-    articles = articles.where(section_id: args['section_id']) if args['section_id']
+    articles = Article.order(created_at: :desc).published
+
+    if args['section_id'] && args['include_subsections']
+      # NOTE: only works with one level of nesting
+      # Fix if multiple levels of nesting introduced
+      subsection_ids = Section.find(args['section_id']).subsections.map do |s| s.id end
+      subsection_ids << args['section_id']
+      articles = articles.where(section_id: subsection_ids)
+    elsif args['section_id']
+      articles = articles.where(section_id: args['section_id'])
+    end
 
     articles = articles.offset(args['offset']) if args['offset']
     articles = articles.limit(args['limit']) if args['limit']
     
-    return articles.published
+    return articles
   end
 end

--- a/app/graphql/resolvers/get_latest_unpublished_articles.rb
+++ b/app/graphql/resolvers/get_latest_unpublished_articles.rb
@@ -1,0 +1,39 @@
+class Resolvers::GetLatestUnpublishedArticles < Resolvers::ArticleQueryFunction
+
+    argument :section_id, types.ID
+    argument :offset, types.Int
+    argument :limit, types.Int
+    argument :include_subsections, types.Boolean
+  
+    # return type from the mutation
+    type types[!Types::ArticleType]
+  
+    # the mutation method
+    # _obj - is parent object, which in this case is nil
+    # _args - are the arguments passed
+    # _ctx - is the GraphQL context (which would be discussed later)
+    def call(_obj, args, ctx)
+      if !Authentication::admin_is_valid(ctx)
+        return GraphQL::ExecutionError.new("Invalid user token. Please log in.")
+      end
+
+      articles = Article.order(created_at: :desc).unpublished
+  
+      if args['section_id'] && args['include_subsections']
+        # NOTE: only works with one level of nesting
+        # Fix if multiple levels of nesting introduced
+        subsection_ids = Section.find(args['section_id']).subsections.map do |s| s.id end
+        subsection_ids << args['section_id']
+        articles = articles.where(section_id: subsection_ids)
+      elsif args['section_id']
+        articles = articles.where(section_id: args['section_id'])
+      end
+  
+      articles = articles.offset(args['offset']) if args['offset']
+      articles = articles.limit(args['limit']) if args['limit']
+
+      Authentication::generate_new_header(ctx) if articles
+      
+      return articles
+    end
+  end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -88,6 +88,8 @@ field :allUsersWithRoles, !types[Types::UserType] do
 
   field :latestArticles, function: Resolvers::GetLatestArticles.new
 
+  field :latestUnpublishedArticles, function: Resolvers::GetLatestUnpublishedArticles.new
+
   field :sectionBySlug do
     type Types::SectionType
     argument :slug, !types.String


### PR DESCRIPTION
For some departments like Sports, almost all articles fall under a subsection, meaning that currently their articles do not show up in the main section page. The include_subsections flag, when set to true, will allow subsection content to be shown on the main page, and will be accompanied with the corresponding change on stuyspec.com. In addition, latestUnpublishedArticles can be used for CMS management of unpublished articles.