### PR TITLE
Feature/featured media

### DIFF
--- a/app/graphql/resolvers/create_medium.rb
+++ b/app/graphql/resolvers/create_medium.rb
@@ -1,9 +1,14 @@
 class Resolvers::CreateMedium < Resolvers::MutationFunction
 
   # arguments passed as "args"
+  # TODO: make is_featured mandatory
   argument :title, !types.String
   argument :article_id, types.Int
   argument :user_id, !types.Int
+  argument :is_featured do
+    type types.Boolean
+    description 'Whether the medium will be shown at the top of its article.'
+  end
   argument :caption, types.String
   argument :media_type, !types.String
   argument :attachment_b64, as: :attachment do
@@ -47,6 +52,7 @@ class Resolvers::CreateMedium < Resolvers::MutationFunction
         title: args["title"],
         article_id: args["article_id"],
         profile_id: profile.id,
+        is_featured: args["is_featured"] || false,
         caption: args["caption"],
         media_type: args["media_type"],
         attachment: args["attachment"],

--- a/app/graphql/types/medium_type.rb
+++ b/app/graphql/types/medium_type.rb
@@ -5,7 +5,14 @@ Types::MediumType = GraphQL::ObjectType.define do
   field :profile, !Types::ProfileType
   field :user, !Types::UserType
   field :title, !types.String
-  field :media_type, !types.String
+  field :media_type do
+    type !types.String
+    description 'Currently supports "illustration" and "photo".'
+  end
+  field :is_featured do
+    type !types.Boolean
+    description 'Whether the medium will be shown at the top of its article.'
+  end
   field :caption, types.String
   field :article, Types::ArticleType
   field :attachment_url, !types.String


### PR DESCRIPTION
Add `is_featured` field to media in order to remove the need for the SPEC_CAROUSEL psuedo-HTML hack currently in use to mark certain articles as utilizing a gallery. The `is_featured` field was already present in the database, but will now be utilized. Also added documentation to a media field. That will be expanded over time.