### PR TITLE
updated role creation

### DIFF
--- a/app/graphql/resolvers/create_user.rb
+++ b/app/graphql/resolvers/create_user.rb
@@ -5,7 +5,7 @@ class Resolvers::CreateUser < Resolvers::MutationFunction
   argument :email, !types.String
   argument :password, !types.String
   argument :password_confirmation, !types.String
-  argument :role, !types.String
+  argument :role, !types[types.String]
   argument :profile_picture_b64, as: :attachment do
       type types.String
       description 'The base64 encoded version of the profile picture.'
@@ -34,9 +34,11 @@ class Resolvers::CreateUser < Resolvers::MutationFunction
       created_at: Time.now,
       profile_picture: args["attachment"] || nil,
     )
-    role = Role.find_by(title: args["role"])
-    if args["role"] and role != nil and !@new_user.roles.include?(role)
-      @new_user.roles << role
+    args["role"].each do |role|
+      roley = Role.find_by(title: role)
+      if roley and role != nil and !@new_user.roles.include?(roley)
+        @new_user.roles << roley
+      end
     end
     Authentication::generate_new_header(ctx) if @new_user.save!
     return @new_user

--- a/app/graphql/resolvers/update_user.rb
+++ b/app/graphql/resolvers/update_user.rb
@@ -4,7 +4,7 @@ class Resolvers::UpdateUser < Resolvers::MutationFunction
   argument :first_name, types.String
   argument :last_name, types.String
   argument :email, types.String
-  argument :role, types.String
+  argument :role, !types[types.String]
   argument :profile_picture_b64, as: :attachment do
       type types.String
       description 'The base64 encoded bersion of the attatchment to upload.'
@@ -35,9 +35,12 @@ class Resolvers::UpdateUser < Resolvers::MutationFunction
         save = "" if save =~ /\d/ else save
         @user.slug = args["first_name"].downcase + "-" + args["last_name"].downcase + save
       end
-      role = Role.find_by(title: args["role"])
-      if args["role"] and role != nil and !@user.roles.include?(role)
-        @user.roles << role
+      @user.roles.clear
+      args["role"].each do |role|
+        roley = Role.find_by(title: role)
+        if roley and role != nil
+          @user.roles << roley
+        end
       end
       Authentication::generate_new_header(ctx) if @user.save!
     end


### PR DESCRIPTION
Addresses #158. Edits the user mutation so that it can accept arrays of roles instead of singular roles. Links to stuyspec/cms#45, so both pull requests must be approved for the change to be properly implemented. 